### PR TITLE
feat: support container.hasValue

### DIFF
--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -10,6 +10,8 @@ import { Cat } from './fixtures/class_extend/cat';
 import ExecutionClazzA from './fixtures/execution/a';
 import ExecutionClazzB from './fixtures/execution/b';
 import { HandlerDemo, CONFIG_ALL } from './fixtures/handler_resolve/handler';
+import ClassA from './fixtures/value/a';
+import ClassB from './fixtures/value/b';
 
 const ctx = {};
 const container = new Container('default');
@@ -227,5 +229,46 @@ describe('handler', () => {
             expect(err).toBeDefined();
             expect(err.message).toMatch('handler was not found in the container');
         }
+    });
+});
+
+describe('hasValue', () => {
+    let container: Container;
+    beforeAll(() => {
+        container = new Container('value');
+    });
+
+    it('container should check value as expected with type', () => {
+        expect(container.hasValue({ type: ClassA })).toBeFalsy();
+        expect(container.hasValue({ id: ClassA })).toBeFalsy();
+
+        // set { type: clazz }
+        container.set({ type: ClassA });
+        expect(container.hasValue({ type: ClassA })).toBeFalsy();
+
+        // set { id: clazz }
+        container.set({ id: ClassA });
+        expect(container.hasValue({ type: ClassA })).toBeFalsy();
+
+        // set { id: clazz, value: value }
+        container.set({ id: ClassA, value: new ClassA('foo') });
+        expect(container.hasValue({ type: ClassA })).toBeTruthy();
+    });
+
+    it('container should check value as expected with id', () => {
+        expect(container.hasValue({ type: ClassB })).toBeFalsy();
+        expect(container.hasValue({ id: ClassB })).toBeFalsy();
+
+        // set { type: clazz }
+        container.set({ type: ClassA });
+        expect(container.hasValue({ id: ClassA })).toBeFalsy();
+
+        // set { id: clazz }
+        container.set({ id: ClassA });
+        expect(container.hasValue({ id: ClassA })).toBeFalsy();
+
+        // set { id: clazz, value: value }
+        container.set({ id: ClassA, value: new ClassA('foo') });
+        expect(container.hasValue({ id: ClassA })).toBeTruthy();
     });
 });

--- a/test/fixtures/value/a.ts
+++ b/test/fixtures/value/a.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "../../../src";
+
+@Injectable()
+export default class A {
+  private name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+}

--- a/test/fixtures/value/b.ts
+++ b/test/fixtures/value/b.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "../../../src";
+
+@Injectable({ id: 'classb' })
+export default class B {
+  private name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+}


### PR DESCRIPTION
对全局 container 增加 `hasValue` 的支持，参数和 `container.get` 一致，根据获取到的 md 判断是否存在 value 值。

这里的作用是，`@artus/core` 在启动期时会执行用户注册的生命周期钩子，譬如 `configDidLoad` 钩子中用户手动对某个 class 实例化后注入到 container 中，此时框架启动期后续执行的兜底 module loader 执行 `container.set` 会覆盖掉用户注入的 class 实例。

经过讨论，增加 `hasValue` 判断后，内核可以更改为对于没有 value 值的类或者实体进行注入，这个是符合开发者直觉和预期的。

PS：Execution container 不存在这样的需求，故不提供对应的 `hasValue` 方法