### PR TITLE
feat: support lazy injectable

### DIFF
--- a/src/decorator/injectable.ts
+++ b/src/decorator/injectable.ts
@@ -1,9 +1,21 @@
-import { InjectableOption, ScopeEnum } from '../types';
-import { setMetadata } from '../util';
-import { CLASS_CONSTRUCTOR } from '../constant';
+import { InjectableOption, ReflectMetadataType, ScopeEnum } from '../types';
+import { recursiveGetMetadata, setMetadata } from '../util';
+import { CLASS_CONSTRUCTOR, CLASS_PROPERTY, INJECT_HANDLER_PROPS, LAZY_HANDLER } from '../constant';
 
 export function Injectable(options?: InjectableOption): ClassDecorator {
   return (target: any) => {
-    setMetadata(CLASS_CONSTRUCTOR, { id: target, scope: ScopeEnum.SINGLETON, ...options }, target);
+    const md = { id: target, scope: ScopeEnum.SINGLETON, lazy: false, ...options };
+    setMetadata(CLASS_CONSTRUCTOR, md, target);
+
+    // make all properties lazy
+    if (md.lazy) {
+      const props = recursiveGetMetadata(CLASS_PROPERTY, target) as ReflectMetadataType[];
+      const handlerProps = recursiveGetMetadata(
+        INJECT_HANDLER_PROPS,
+        target,
+      ) as ReflectMetadataType[];
+      const properties = (props ?? []).concat(handlerProps ?? []);
+      properties.forEach(property => property.handler = LAZY_HANDLER);
+    }
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface InjectOptions {
 export interface InjectableOption {
   id?: Identifier;
   scope?: ScopeEnum;
+  lazy?: boolean;
 }
 
 export interface InjectableDefinition<T = unknown> {

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -9,6 +9,7 @@ import ExecutionClazzA from './fixtures/execution/a';
 import { HandlerDemo, CONFIG_ALL } from './fixtures/handler_resolve/handler';
 import ClassA from './fixtures/value/a';
 import ClassB from './fixtures/value/b';
+import LazyCClass from './fixtures/lazy/lazy_c';
 import LazyBClass from './fixtures/lazy/lazy_b';
 import LazyAClass from './fixtures/lazy/lazy_a';
 
@@ -285,5 +286,11 @@ describe('container#lazy', () => {
     expect(instance.lazyB).toBeInstanceOf(LazyBClass);
     expect(instance.lazyB === instance.lazyB).toBeTruthy();
     expect(instance.lazyB.name).toBe('lazyBClass');
+    container.set({ type: LazyCClass });
+    const instanceb = container.get(LazyBClass);
+    expect(instanceb.lazyC).toBeDefined();
+    expect(instanceb.lazyC).toBeInstanceOf(LazyCClass);
+    expect(instanceb.lazyC === instanceb.lazyC).toBeTruthy();
+    expect(instanceb.lazyC.name).toBe('lazyCClass');
   });
 });

--- a/test/fixtures/lazy/lazy_a.ts
+++ b/test/fixtures/lazy/lazy_a.ts
@@ -1,8 +1,8 @@
 import LazyB from './lazy_b';
 import { Inject, Injectable } from '../../../src';
 
-@Injectable()
+@Injectable({ lazy: true })
 export default class LazyAClass {
-  @Inject({ lazy: true })
+  @Inject()
   lazyB!: LazyB;
 }

--- a/test/fixtures/lazy/lazy_b.ts
+++ b/test/fixtures/lazy/lazy_b.ts
@@ -1,3 +1,9 @@
+import LazyC from './lazy_c';
+import { Inject, Injectable } from '../../../src';
+
+@Injectable()
 export default class LazyBClass {
+  @Inject({ lazy: true })
+  lazyC!: LazyC;
   public name = 'lazyBClass';
 }

--- a/test/fixtures/lazy/lazy_c.ts
+++ b/test/fixtures/lazy/lazy_c.ts
@@ -1,0 +1,3 @@
+export default class LazyCClass {
+  public name = 'lazyCClass';
+}


### PR DESCRIPTION
此 PR 旨在支持 `@Injectable({ lazy: true })`，此时类下所有的属性均采用 lazy handler 的方式加载