### PR TITLE
fix: proxy function lost this type

### DIFF
--- a/src/lazy_helper.ts
+++ b/src/lazy_helper.ts
@@ -7,9 +7,12 @@ function createHandler<T extends Object>(delayedObject: () => T): ProxyHandler<T
   const handler: ProxyHandler<T> = {};
   const install = (name: keyof ProxyHandler<T>) => {
     handler[name] = (...args: any[]) => {
-      args[0] = delayedObject();
+      const instance = args[0] = delayedObject();
       const method = Reflect[name];
-      return (method as any)(...args);
+      const result = (method as any)(...args);
+      return typeof result === 'function'
+        ? result.bind(instance)
+        : result;
     };
   };
   reflectMethods.forEach(install);

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -12,6 +12,7 @@ import ClassB from './fixtures/value/b';
 import LazyCClass from './fixtures/lazy/lazy_c';
 import LazyBClass from './fixtures/lazy/lazy_b';
 import LazyAClass from './fixtures/lazy/lazy_a';
+import LazyDClass from './fixtures/lazy/lazy_d';
 
 const ctx = {};
 const container = new Container('default');
@@ -282,10 +283,13 @@ describe('container#lazy', () => {
     const instance = container.get(LazyAClass);
     expect(instance).toBeInstanceOf(LazyAClass);
     container.set({ type: LazyBClass });
+    container.set({ type: LazyDClass });
     expect(instance.lazyB).toBeDefined();
     expect(instance.lazyB).toBeInstanceOf(LazyBClass);
     expect(instance.lazyB === instance.lazyB).toBeTruthy();
     expect(instance.lazyB.name).toBe('lazyBClass');
+    expect(instance.lazyB.testLazyD()).toBe('a,b');
+
     container.set({ type: LazyCClass });
     const instanceb = container.get(LazyBClass);
     expect(instanceb.lazyC).toBeDefined();

--- a/test/fixtures/lazy/lazy_b.ts
+++ b/test/fixtures/lazy/lazy_b.ts
@@ -1,9 +1,19 @@
 import LazyC from './lazy_c';
+import LazyD from './lazy_d';
 import { Inject, Injectable } from '../../../src';
 
 @Injectable()
 export default class LazyBClass {
   @Inject({ lazy: true })
   lazyC!: LazyC;
+
+  @Inject({ lazy: true })
+  lazyD!: LazyD;
+
   public name = 'lazyBClass';
+
+  testLazyD() {
+    this.lazyD.set('a', 'b');
+    return this.lazyD.doSomething();
+  }
 }

--- a/test/fixtures/lazy/lazy_d.ts
+++ b/test/fixtures/lazy/lazy_d.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '../../../src';
+
+@Injectable()
+export default class LazyDClass extends Map {
+  doSomething() {
+    return Array.from(this.entries()).join(',');
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

Proxy 的时候需要判断一下类型，如果是函数需要纠正 this ，否则有问题。

##### Description of change
<!-- Provide a description of the change below this comment. -->

