### PR TITLE
fix: execution container not extends parent

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -67,10 +67,9 @@ export default class Container implements ContainerType {
   public set(options: Partial<InjectableDefinition>) {
     if (options.id && !isUndefined(options.value)) {
       const md: InjectableMetadata = {
+        ...options,
         id: options.id,
-        value: options.value,
         scope: options.scope ?? ScopeEnum.SINGLETON,
-        type: options.type,
       };
       this.registry.set(md.id, md);
       /**

--- a/src/execution_container.ts
+++ b/src/execution_container.ts
@@ -16,7 +16,7 @@ export default class ExecutionContainer extends Container {
 
   public get<T = unknown>(
     id: Identifier<T>,
-    options: { noThrow?: boolean; defaultValue?: any } = {}
+    options: { noThrow?: boolean; defaultValue?: any } = {},
   ): T {
     const md = this.getDefinition(id);
     if (!md) {

--- a/src/execution_container.ts
+++ b/src/execution_container.ts
@@ -16,7 +16,7 @@ export default class ExecutionContainer extends Container {
 
   public get<T = unknown>(
     id: Identifier<T>,
-    options: { noThrow?: boolean; defaultValue?: any } = {},
+    options: { noThrow?: boolean; defaultValue?: any } = {}
   ): T {
     const md = this.getDefinition(id) ?? this.parent.getDefinition(id);
     if (!md) {
@@ -33,12 +33,24 @@ export default class ExecutionContainer extends Container {
     return value;
   }
 
+  public getDefinition<T = unknown>(id: Identifier<T>): InjectableMetadata<T> | undefined {
+    return super.getDefinition(id) ?? this.parent.getDefinition(id);
+  }
+
+  public getInjectableByTag(tag: string): any[] {
+    let tags = super.getInjectableByTag(tag);
+    if (!tags || tags.length === 0) {
+      tags = this.parent.getInjectableByTag(tag);
+    }
+    return tags;
+  }
+
   public getCtx(): any {
     return this.ctx;
   }
 
   public getHandler(name: string | symbol): HandlerFunction | undefined {
-    return this.handlerMap.get(name) ?? this.parent.getHandler(name);
+    return super.getHandler(name) ?? this.parent.getHandler(name);
   }
 
   private setValue(md: InjectableMetadata, value: any) {

--- a/src/execution_container.ts
+++ b/src/execution_container.ts
@@ -18,7 +18,7 @@ export default class ExecutionContainer extends Container {
     id: Identifier<T>,
     options: { noThrow?: boolean; defaultValue?: any } = {}
   ): T {
-    const md = this.getDefinition(id) ?? this.parent.getDefinition(id);
+    const md = this.getDefinition(id);
     if (!md) {
       if (options.noThrow) {
         return options.defaultValue;

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -340,7 +340,7 @@ describe('container#lazy', () => {
     } catch (err) {
       expect(err).toBeDefined();
       expect(err.message).toContain(
-        `[@artus/injection] cannot inject 'LazyConstructorClass' constructor argument by lazy`
+        `[@artus/injection] cannot inject 'LazyConstructorClass' constructor argument by lazy`,
       );
     }
   });
@@ -361,13 +361,13 @@ describe('container#scopeEscape', () => {
     expect(() => {
       container.get(EscapeA);
     }).toThrow(
-      `[@artus/injection] 'EscapeA' with 'singleton' scope cannot be injected property 'escapeB' with 'execution' scope`
+      `[@artus/injection] 'EscapeA' with 'singleton' scope cannot be injected property 'escapeB' with 'execution' scope`,
     );
 
     expect(() => {
       container.get(EscapeE);
     }).toThrow(
-      `[@artus/injection] 'EscapeE' with 'singleton' scope cannot be injected constructor argument at index '0' with 'execution' scope`
+      `[@artus/injection] 'EscapeE' with 'singleton' scope cannot be injected constructor argument at index '0' with 'execution' scope`,
     );
   });
 

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -120,6 +120,11 @@ describe('container', () => {
       expect(execContainer.get('hasValue')).toBe('hello');
       expect(execContainer.get('hasValue')).toBe('hello');
     });
+
+    it('should get definition from parent', () => {
+      const definition = execContainer.getDefinition(Phone);
+      expect(definition).toBeDefined();
+    });
   });
 });
 
@@ -132,10 +137,15 @@ describe('container#tag', () => {
   describe('getInjectableByTag', () => {
     it('should get classes by tag', () => {
       const container = new Container('container#tag');
+      const childContainer = new ExecutionContainer({}, container);
       container.set({ type: Foo });
       const clazzes = container.getInjectableByTag('controller');
       expect(clazzes.length).toBeGreaterThan(0);
       expect(clazzes[0]).toEqual(Foo);
+
+      const clazzes3 = childContainer.getInjectableByTag('controller');
+      expect(clazzes3.length).toBeGreaterThan(0);
+      expect(clazzes3[0]).toEqual(Foo);
 
       const clazzes2 = container.getInjectableByTag('middleware');
       expect(clazzes2.length).toBeGreaterThan(0);
@@ -330,7 +340,7 @@ describe('container#lazy', () => {
     } catch (err) {
       expect(err).toBeDefined();
       expect(err.message).toContain(
-        `[@artus/injection] cannot inject 'LazyConstructorClass' constructor argument by lazy`,
+        `[@artus/injection] cannot inject 'LazyConstructorClass' constructor argument by lazy`
       );
     }
   });
@@ -351,13 +361,13 @@ describe('container#scopeEscape', () => {
     expect(() => {
       container.get(EscapeA);
     }).toThrow(
-      `[@artus/injection] 'EscapeA' with 'singleton' scope cannot be injected property 'escapeB' with 'execution' scope`,
+      `[@artus/injection] 'EscapeA' with 'singleton' scope cannot be injected property 'escapeB' with 'execution' scope`
     );
 
     expect(() => {
       container.get(EscapeE);
     }).toThrow(
-      `[@artus/injection] 'EscapeE' with 'singleton' scope cannot be injected constructor argument at index '0' with 'execution' scope`,
+      `[@artus/injection] 'EscapeE' with 'singleton' scope cannot be injected constructor argument at index '0' with 'execution' scope`
     );
   });
 


### PR DESCRIPTION
修复 execution container 没有从 parent container 获取 tag 以及 definition 相关信息

fix #62 